### PR TITLE
visit_ImportFrom: Prevent AttributeError

### DIFF
--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -328,12 +328,16 @@ class CLikeTranspiler(ast.NodeVisitor):
         if node.module in self._ignored_module_set:
             return ""
 
-        had_import_exception = False
-        try:
-            imported_name = importlib.import_module(node.module)
-        except ImportError:
+        if node.module:
+            had_import_exception = False
+            try:
+                imported_name = importlib.import_module(node.module)
+            except ImportError:
+                had_import_exception = True
+                imported_name = node.module
+        else:
+            # Import from '.'
             had_import_exception = True
-            imported_name = node.module
 
         names = [self.visit(n) for n in node.names]
         for name, asname in names:

--- a/py2many/clike.py
+++ b/py2many/clike.py
@@ -528,6 +528,10 @@ class CLikeTranspiler(ast.NodeVisitor):
                 f"{name} unimplemented on line {node.lineno}:{node.col_offset}"
             )
 
+    def visit_NamedExpr(self, node):
+        target = self.visit(node.target)
+        return self.visit_unsupported_body(node, f"named expr {target}", node.value)
+
     def visit_Delete(self, node):
         body = [self.visit(t) for t in node.targets]
         return self.visit_unsupported_body(node, "del", body)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3{8,9}
+envlist = py3{8,9,10}
 skip_missing_interpreters = true
 
 [testenv]
@@ -16,7 +16,7 @@ passenv =
     GOPATH
     GOCACHE
 deps =
-    unittest-expander
+    git+https://github.com/zuo/unittest_expander
     pytest-cov
     black
     astpretty


### PR DESCRIPTION
AttributeError occurs because node.module is None
when `from . import ...`